### PR TITLE
Update YAML indentation error in PVC manifest

### DIFF
--- a/docs/09-cks-challenges/01-challenge-1.md
+++ b/docs/09-cks-challenges/01-challenge-1.md
@@ -64,8 +64,8 @@ Do the tasks in this order:
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
-    name: alpha-pvc
-    namespace: alpha
+      name: alpha-pvc
+      namespace: alpha
     spec:
       accessModes:
       - ReadWriteMany


### PR DESCRIPTION
Currently, the `name` and `namespace` fields are top-level fields in the PVC YAML manifest for the Challenge 1 task for:

> 'alpha-pvc' should be bound to 'alpha-pv'. Delete and Re-create it if necessary.


This PR fixes the indentation error by moving the fields under the `metadata` dict. 